### PR TITLE
fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ SFWBar (Sway Floating Window Bar) is a flexible taskbar application for
 wayland compositors, designed with a stacking layout in mind. 
 Originally developed for [Sway](https://github.com/swaywm/sway), SFWBar
 will work with other wayland compositors supporting layer shell protocol,
-and the taskbar functionality shall for with any compositor supportinig
+and the taskbar functionality shall work with any compositor supportinig
 foreign toplevel protocol, but the pager, switcher and placement 
 functionality requires sway (or at least i3 IPC support).
 


### PR DESCRIPTION
I believe the README had a typo, or rather a strange word was used in a place where I did not expect it.