### PR TITLE
cchart.c: Don't deduplicate values

### DIFF
--- a/src/basewidget.c
+++ b/src/basewidget.c
@@ -257,7 +257,8 @@ void base_widget_set_value ( GtkWidget *self, gchar *value )
   g_free(priv->value);
   priv->value = value;
 
-  if(base_widget_cache(&priv->value,&priv->evalue) || BASE_WIDGET_GET_CLASS(self)->no_value_cache)
+  if(base_widget_cache(&priv->value,&priv->evalue) ||
+      BASE_WIDGET_GET_CLASS(self)->no_value_cache)
     base_widget_update_value(self);
 
   g_mutex_lock(&widget_mutex);
@@ -514,7 +515,8 @@ void base_widget_emit_trigger ( gchar *trigger )
     priv = base_widget_get_instance_private(BASE_WIDGET(iter->data));
     if(!priv->trigger || g_ascii_strcasecmp(trigger,priv->trigger))
       continue;
-    if(base_widget_cache(&priv->value,&priv->evalue) || BASE_WIDGET_GET_CLASS(iter->data)->no_value_cache)
+    if(base_widget_cache(&priv->value,&priv->evalue) ||
+        BASE_WIDGET_GET_CLASS(iter->data)->no_value_cache)
       base_widget_update_value(iter->data);
     if(base_widget_cache(&priv->style,&priv->estyle))
       base_widget_style(iter->data);
@@ -543,7 +545,8 @@ gpointer base_widget_scanner_thread ( GMainContext *gmc )
       priv = base_widget_get_instance_private(BASE_WIDGET(iter->data));
       if(base_widget_get_next_poll(iter->data)<=ctime)
       {
-        if(base_widget_cache(&priv->value,&priv->evalue) || BASE_WIDGET_GET_CLASS(iter->data)->no_value_cache)
+        if(base_widget_cache(&priv->value,&priv->evalue) ||
+            BASE_WIDGET_GET_CLASS(iter->data)->no_value_cache)
           g_main_context_invoke(gmc,(GSourceFunc)base_widget_update_value,
               iter->data);
         if(base_widget_cache(&priv->style,&priv->estyle))

--- a/src/basewidget.c
+++ b/src/basewidget.c
@@ -257,7 +257,7 @@ void base_widget_set_value ( GtkWidget *self, gchar *value )
   g_free(priv->value);
   priv->value = value;
 
-  if(base_widget_cache(&priv->value,&priv->evalue))
+  if(base_widget_cache(&priv->value,&priv->evalue) || BASE_WIDGET_GET_CLASS(self)->no_value_cache)
     base_widget_update_value(self);
 
   g_mutex_lock(&widget_mutex);
@@ -514,7 +514,7 @@ void base_widget_emit_trigger ( gchar *trigger )
     priv = base_widget_get_instance_private(BASE_WIDGET(iter->data));
     if(!priv->trigger || g_ascii_strcasecmp(trigger,priv->trigger))
       continue;
-    if(base_widget_cache(&priv->value,&priv->evalue))
+    if(base_widget_cache(&priv->value,&priv->evalue) || BASE_WIDGET_GET_CLASS(iter->data)->no_value_cache)
       base_widget_update_value(iter->data);
     if(base_widget_cache(&priv->style,&priv->estyle))
       base_widget_style(iter->data);
@@ -543,7 +543,7 @@ gpointer base_widget_scanner_thread ( GMainContext *gmc )
       priv = base_widget_get_instance_private(BASE_WIDGET(iter->data));
       if(base_widget_get_next_poll(iter->data)<=ctime)
       {
-        if(base_widget_cache(&priv->value,&priv->evalue))
+        if(base_widget_cache(&priv->value,&priv->evalue) || BASE_WIDGET_GET_CLASS(iter->data)->no_value_cache)
           g_main_context_invoke(gmc,(GSourceFunc)base_widget_update_value,
               iter->data);
         if(base_widget_cache(&priv->style,&priv->estyle))

--- a/src/basewidget.h
+++ b/src/basewidget.h
@@ -18,6 +18,7 @@ struct _BaseWidgetClass
 
   void (*update_value)(GtkWidget *self);
   GtkWidget *(*get_child)(GtkWidget *self);
+  gboolean no_value_cache;
 };
 
 typedef struct _BaseWidgetPrivate BaseWidgetPrivate;

--- a/src/cchart.c
+++ b/src/cchart.c
@@ -42,6 +42,7 @@ static void cchart_class_init ( CChartClass *kclass )
   GTK_WIDGET_CLASS(kclass)->destroy = cchart_destroy;
   BASE_WIDGET_CLASS(kclass)->update_value = cchart_update_value;
   BASE_WIDGET_CLASS(kclass)->get_child = cchart_get_child;
+  BASE_WIDGET_CLASS(kclass)->no_value_cache = TRUE;
 }
 
 static void cchart_init ( CChart *self )


### PR DESCRIPTION
This fixes charts for data sources that might give back the same
value repeatably. Most obvious to see when trying to monitor the
disk or swap (the values may not change for a long time).

This still does not allow for true static value assignments (which is a pretty niche case anyway).

Testcase:
```
layout ":center" {
	chart {
		style = "disk"
		interval = 2000
		value = (Disk("/", "%used") / 100)
	}
}

#CSS
window#sfwbar {
	-GtkWidget-direction: top;
}

chart {
	color: yellow;
	background-color: black;
	min-width: 50px;
	min-height: 28px;
	margin: 0 1px;
	border: 1px inset rgba(128, 128, 128, 0.5);
}

chart#disk {
	color: purple;
}
```

This is most properly not the correct solution (and the overlong `if()`s look ugly).
I am not really familiar with GTK on the C side (usually only using it with its Python bindings). This is just the result of trying to figure out why some of my monitor charts weren't working correctly while others were working fine. With this change they now move all in (approximately) the same speed.

FWIW, here is a complete monitor widget I wrote for testing:
<details><summary>system_monitor.widget</summary>

![sfwbar_monitor](https://user-images.githubusercontent.com/35009135/188325993-10995559-caa0-49a6-8933-cef41a59b805.png)

```
scanner {
	# Extract memory usage information
	file("/proc/meminfo") {
		MemTotal = RegEx("^MemTotal:[\t ]*([0-9]+)[\t ]")
		MemFree = RegEx("^MemFree:[\t ]*([0-9]+)[\t ]")
		MemCache = RegEx("^Cached:[\t ]*([0-9]+)[\t ]")
		MemBuff = Regex("^Buffers:[\t ]*([0-9]+)[\t ]")
		SwapTotal = RegEx("^SwapTotal:[\t ]*([0-9]+)[\t ]")
		SwapFree = RegEx("^SwapFree:[\t ]*([0-9]+)[\t ]")
	}

	# Add up CPU utilization stats across all CPUs
	file("/proc/stat") {
		CpuCountTotal = Regex("^cpu([0-9]+)", Last)
		CpuUserTotal = RegEx("^cpu [\t ]*([0-9]+)",Sum)
		CpuNiceTotal = RegEx("^cpu [\t ]*[0-9]+ ([0-9]+)",Sum)
		CpuSystemTotal = RegEx("^cpu [\t ]*[0-9]+ [0-9]+ ([0-9]+)",Sum)
		CpuIdleTotal = RegEx("^cpu [\t ]*[0-9]+ [0-9]+ [0-9]+ ([0-9]+)",Sum)
	}

	file("/proc/loadavg") {
		LoadAvg1Str = Regex("^([0-9.]+)", Last)
		LoadAvg5Str = Regex("^[0-9.]+[\t ]([0-9.]+)", Last)
		LoadAvg15Str = Regex("^[0-9.]+[\t ][0-9.]+[\t ]([0-9.]+)", Last)
	}
}

# FIXME: figure out how the Cached() thing works and how to clear the cache again

define CpuCount = (CpuCountTotal.count)
# TODO: these cry for figuring out how to use functions
define CpuUser = (CpuUserTotal - CpuUserTotal.pval)
define CpuNice = (CpuNiceTotal - CpuNiceTotal.pval)
define CpuSystem = (CpuSystemTotal - CpuSystemTotal.pval)
define CpuIdle = (CpuIdleTotal - CpuIdleTotal.pval)

define LoadAvg1 = Val(LoadAvg1Str)
define LoadAvg5 = Val(LoadAvg5Str)
define LoadAvg15 = Val(LoadAvg15Str)
define LoadAvgScale = If(LoadAvg1 > CpuCount, LoadAvg1, CpuCount)

define CpuTotal = (CpuUser + CpuNice + CpuSystem + CpuIdle)
define CpuUsage = ((CpuTotal - CpuIdle) / CpuTotal)
define SwapUsed = (SwapTotal - SwapFree)
# TODO: Does MemBuff really count as free-able?
define MemAvail = (MemFree + MemCache + MemBuff)
define MemUsed = (MemTotal - MemAvail)
define DiskUsed = (Disk("/", "total") - Disk("/", "avail"))

# TODO: these cry for figuring out how to use functions. also: is there some kind of format string?
define MemUsedHuman = Pad(Str(MemUsed / 1024 / 1024, 2) + " GiB", 9)
define MemAvailHuman = Pad(Str(MemAvail / 1024 / 1024, 2) + " GiB", 9)
define MemTotalHuman = Pad(Str(MemTotal / 1024 / 1024, 2) + " GiB", 9)
define SwapUsedHuman = Pad(Str(SwapUsed / 1024 / 1024, 2) + " GiB", 9)
define SwapFreeHuman = Pad(Str(SwapFree / 1024 / 1024, 2) + " GiB", 9)
define SwapTotalHuman = Pad(Str(SwapTotal / 1024 / 1024, 2) + " GiB", 9)
define DiskUsedHuman = Pad(Str(DiskUsed / 1024 / 1024 / 1024, 2) + " GiB", 11)
define DiskAvailHuman = Pad(Str(Disk("/", "avail") / 1024 / 1024 / 1024, 2) + " GiB", 11)
define DiskTotalHuman = Pad(Str(Disk("/", "total") / 1024 / 1024 / 1024, 2) + " GiB", 11)

layout {
	style = "monitorlayout"
	chart {
		style = "cpu"
		interval = 2000
		value = CpuUsage
		tooltip = "<tt><b>CPU</b>\n" + Str(CpuUsage * 100, 2) + "% All " + Str(CpuCount, 0) + " core usage</tt>"
	}
	chart {
		style = "memory"
		interval = 2000
		value = (MemUsed / MemTotal)
		tooltip = "<tt> <b>Memory</b>\n" + MemTotalHuman + " Total\n" + MemUsedHuman + " Used\n" + MemAvailHuman + " Available</tt>"
	}
	chart {
		style = "swap"
		interval = 2000
		value = (SwapUsed / SwapTotal)
		tooltip = "<tt><b> Swap</b>\n" + SwapTotalHuman + " Total\n" + SwapUsedHuman + " Used\n" + SwapFreeHuman + " Free</tt>"
	}
	chart {
		style = "disk"
		interval = 2000
		value = (Disk("/", "%used") / 100)
		tooltip = "<tt><b> Disk</b>\n" + DiskTotalHuman + " Total\n" + DiskUsedHuman + " Used\n" + DiskAvailHuman + " Available</tt>"
	}
	chart {
		style = "load"
		interval = 2000
		value = (LoadAvg1 / LoadAvgScale)
		tooltip = "<tt><b> Load</b>\n" + Pad(Str(LoadAvg1, 2), 5) + " Average  1 minute\n" + Pad(Str(LoadAvg5, 2), 5) + " Average  5 minutes\n" + Pad(Str(LoadAvg15, 2), 5) + " Average 15 minutes\n\nCurrent scale: " + Str(LoadAvgScale, 2) + "</tt>"
	}
}

#CSS

chart {
	background-color: black;
	color: yellow;
	min-width: 50px;
	min-height: 28px;
	margin: 0 1px;
	border: 1px inset rgba(128, 128, 128, 0.5);
}

chart#cpu {
	color: blue;
	color: #42b2b2;
}

chart#memory {
	color: green;
	color: #339933;
}

chart#swap {
	color: purple;
	color: #7f007f;
}

chart#disk {
	color: yellow;
	color: #505000;
}

chart#load {
	color: red;
	color: #990000;
}
```
</details>