### PR TITLE
NixOS task switcher using Hyprland

### DIFF
--- a/doc/sfwbar.rst
+++ b/doc/sfwbar.rst
@@ -95,6 +95,10 @@ one of the following bindings: ::
 
 (for non-sway compositors, use SIGUSR1 trigger)
 
+NixOS + Hyprland (probably other non-sway compositors) use: ::
+
+  bind = ALT, Tab, exec, killall -SIGUSR1 .sfwbar-wrapped 
+
 Task switcher is configured in the "switcher" section of the configuration file.
 The following parameters are accepted:
 


### PR DESCRIPTION
killall -SIGUSR1 sfwbar - in NixOS causes:
sfwbar: no process found

sfwbar is running as .sfwbar-wrapped in NixOS