### PR TITLE
Add Fedora installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ ninja -C build
 sudo ninja -C build install
 ```
 
+## Install packages
+
+* [Fedora](https://src.fedoraproject.org/rpms/sfwbar): `sudo dnf install sfwbar`
+
 ## Configuration
 Copy sfwbar.config from /usr/share/sfwbar/ to ~/.config/sfwbar/
 If you prefer to start with something more like tint2 bar, you can


### PR DESCRIPTION
`sfwbar` [packaged](https://src.fedoraproject.org/rpms/sfwbar) for Fedora. Currently available in [updates-testing](https://bodhi.fedoraproject.org/updates/?packages=sfwbar). 