### PR TITLE
Update Readme: add Debian link

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ sudo ninja -C build install
 ## Install packages
 
 * [Fedora](https://src.fedoraproject.org/rpms/sfwbar): `sudo dnf install sfwbar`
+* [Debian](https://tracker.debian.org/pkg/sfwbar): `sudo apt install sfwbar`
 
 ## Configuration
 Copy sfwbar.config from /usr/share/sfwbar/ to ~/.config/sfwbar/


### PR DESCRIPTION
`sfwbar` is now part of "testing" and should migrate into "stable" for the upcoming Debian 13.