### PR TITLE
Fix crash when timeout executes after SNI freed

### DIFF
--- a/src/snimenu.c
+++ b/src/snimenu.c
@@ -97,7 +97,6 @@ static gboolean sni_menu_cancel_ats_suppression ( GtkWidget *menu_obj )
 {
   g_object_set_data(G_OBJECT(menu_obj), "suppress_ats",
       GINT_TO_POINTER(FALSE));
-  g_object_unref(menu_obj);
   return FALSE;
 }
 

--- a/src/snimenu.c
+++ b/src/snimenu.c
@@ -280,6 +280,7 @@ static void sni_menu_get_layout_cb ( GObject *src, GAsyncResult *res,
   GVariantIter *iter;
   gchar *tmp;
   guint32 rev, id;
+  struct ats_timeout_ctx *ctx;
 
   if( !(result = g_dbus_connection_call_finish(G_DBUS_CONNECTION(src), res,
           NULL)) )
@@ -306,7 +307,7 @@ static void sni_menu_get_layout_cb ( GObject *src, GAsyncResult *res,
   g_variant_unref(dict);
   g_variant_unref(result);
 
-  struct ats_timeout_ctx *ctx = g_slice_new(struct ats_timeout_ctx);
+  ctx = g_slice_new(struct ats_timeout_ctx);
   ctx->sni = sni;
   ctx->timeout = g_timeout_add(
     1000, G_SOURCE_FUNC(sni_menu_cancel_ats_suppression), ctx);

--- a/src/snimenu.c
+++ b/src/snimenu.c
@@ -285,7 +285,7 @@ static void sni_menu_get_layout_cb ( GObject *src, GAsyncResult *res,
   g_variant_unref(dict);
   g_variant_unref(result);
   g_timeout_add(1000, G_SOURCE_FUNC(sni_menu_cancel_ats_suppression),
-      g_object_ref(sni->menu_obj));
+      sni->menu_obj);
 }
 
 static void sni_menu_about_to_show_cb ( GDBusConnection *con, GAsyncResult *res,
@@ -347,6 +347,8 @@ void sni_menu_init ( sni_item_t *sni )
     gtk_widget_destroy(sni->menu_obj);
 
   sni->menu_obj = gtk_menu_new();
+  g_signal_connect(G_OBJECT(sni->menu_obj), "destroy",
+      G_CALLBACK(g_source_remove_by_user_data), NULL);
   g_signal_connect(G_OBJECT(sni->menu_obj), "map",
       G_CALLBACK(sni_menu_map_cb), sni);
 

--- a/src/snimenu.c
+++ b/src/snimenu.c
@@ -10,12 +10,6 @@
 #include "gui/menu.h"
 #include "gui/scaleimage.h"
 
-struct ats_timeout_ctx {
-  sni_item_t *sni;
-  guint timeout;
-  gulong handle;
-};
-
 const gchar *sni_menu_iface = "com.canonical.dbusmenu";
 
 static void sni_menu_parse ( GtkWidget *widget, GVariantIter *viter );
@@ -99,17 +93,10 @@ static void sni_menu_map_cb( GtkWidget *menu, sni_item_t *sni )
         (GAsyncReadyCallback)sni_menu_about_to_show_cb, menu);
 }
 
-static void ats_timeout_ctx_free ( struct ats_timeout_ctx *ctx )
+static gboolean sni_menu_cancel_ats_suppression ( GtkWidget *menu_obj )
 {
-  g_signal_handler_disconnect(ctx->sni->cancel, ctx->handle);
-  g_slice_free(struct ats_timeout_ctx, ctx);
-}
-
-static gboolean sni_menu_cancel_ats_suppression ( struct ats_timeout_ctx *ctx )
-{
-  g_object_set_data(G_OBJECT(ctx->sni->menu_obj), "suppress_ats",
+  g_object_set_data(G_OBJECT(menu_obj), "suppress_ats",
       GINT_TO_POINTER(FALSE));
-  ats_timeout_ctx_free(ctx);
   return FALSE;
 }
 
@@ -262,15 +249,6 @@ static void sni_menu_parse ( GtkWidget *widget, GVariantIter *viter )
   g_list_free(children);
 }
 
-static void sni_menu_remove_ats_timeout ( GCancellable *cancel, gpointer data )
-{
-  struct ats_timeout_ctx *ctx = data;
-  (void)cancel;
-
-  g_source_remove(ctx->timeout);
-  ats_timeout_ctx_free(ctx);
-}
-
 static void sni_menu_get_layout_cb ( GObject *src, GAsyncResult *res,
     gpointer data )
 {
@@ -280,7 +258,6 @@ static void sni_menu_get_layout_cb ( GObject *src, GAsyncResult *res,
   GVariantIter *iter;
   gchar *tmp;
   guint32 rev, id;
-  struct ats_timeout_ctx *ctx;
 
   if( !(result = g_dbus_connection_call_finish(G_DBUS_CONNECTION(src), res,
           NULL)) )
@@ -307,12 +284,8 @@ static void sni_menu_get_layout_cb ( GObject *src, GAsyncResult *res,
   g_variant_unref(dict);
   g_variant_unref(result);
 
-  ctx = g_slice_new(struct ats_timeout_ctx);
-  ctx->sni = sni;
-  ctx->timeout = g_timeout_add(
-    1000, G_SOURCE_FUNC(sni_menu_cancel_ats_suppression), ctx);
-  ctx->handle = g_cancellable_connect(
-    sni->cancel, G_CALLBACK(sni_menu_remove_ats_timeout), ctx, NULL);
+  g_timeout_add(1000, G_SOURCE_FUNC(sni_menu_cancel_ats_suppression),
+      g_object_ref(sni->menu_obj));
 }
 
 static void sni_menu_about_to_show_cb ( GDBusConnection *con, GAsyncResult *res,

--- a/src/snimenu.c
+++ b/src/snimenu.c
@@ -284,7 +284,6 @@ static void sni_menu_get_layout_cb ( GObject *src, GAsyncResult *res,
   g_variant_iter_free(iter);
   g_variant_unref(dict);
   g_variant_unref(result);
-
   g_timeout_add(1000, G_SOURCE_FUNC(sni_menu_cancel_ats_suppression),
       g_object_ref(sni->menu_obj));
 }

--- a/src/snimenu.c
+++ b/src/snimenu.c
@@ -97,6 +97,7 @@ static gboolean sni_menu_cancel_ats_suppression ( GtkWidget *menu_obj )
 {
   g_object_set_data(G_OBJECT(menu_obj), "suppress_ats",
       GINT_TO_POINTER(FALSE));
+  g_object_unref(menu_obj);
   return FALSE;
 }
 


### PR DESCRIPTION
When the `sni_menu_cancel_ats_suppression` timeout is called, the `sni_item_t` connected to it may have been freed. This has resulted in consistent crashes that occur when VLC media player is closed. This fixes the crash by removing the timeout before the SNI item is freed.