### PR TITLE
bar: do not use quoted "layout" as CSS name

### DIFF
--- a/src/gui/bar.c
+++ b/src/gui/bar.c
@@ -300,7 +300,7 @@ GtkWidget *bar_grid_from_name ( gchar *addr )
 
   widget = grid_new();
 
-  base_widget_set_style_static(widget, g_strdup("\"layout\""));
+  base_widget_set_style_static(widget, g_strdup("layout"));
 
   if(grid && !g_ascii_strcasecmp(grid,"center"))
   {


### PR DESCRIPTION
I'm not sure why this string included escaped quotes. The change was made in 34c9d917da883f64a63afbd2cbdae53b0fa09a69, but doesn't seem to make sense to me--the only thing this string is used for, from what I can tell, is the CSS name via `gtk_widget_set_name`. And including quotes in such a name makes it impossible to refer to from CSS: `#layout` does not match it, and `#"layout"` is not valid syntax.

This change allows `#layout` to be referenced in CSS.