### PR TITLE
Changed order of new workspaces to append not prepend

### DIFF
--- a/src/workspace.c
+++ b/src/workspace.c
@@ -345,7 +345,7 @@ workspace_t *workspace_new ( gpointer id )
     ws = g_malloc0(sizeof(workspace_t));
     ws->id = id;
     ws->refcount = 0;
-    workspaces = g_list_prepend(workspaces, ws);
+    workspaces = g_list_append(workspaces, ws);
     workspace_ref(id);
     LISTENER_CALL(workspace_new, ws);
   }


### PR DESCRIPTION
In labwc I create 8 workspaces called 1,2,3,4,5,6,7,8. When presented in sfwbar's pager, without sorting turned on, they display in the reverse order 8,7,6,5,4,3,2,1. Changing the code in workspace_new to append instead of prepend fixes that.

I actually use font awesome icons as names (can't paste those here as they don't show properly) so I can't use sorting, and want them to appear in the order I created them in labwc.