### PR TITLE
Remove GT before the icon name "bluetooth-disable"  in bluez.widget

### DIFF
--- a/config/bluez.widget
+++ b/config/bluez.widget
@@ -137,7 +137,7 @@ layout {
   trigger = "bluez_running"
   button "XBluezWidget" {
     style = "module"
-    value = If(!BluezAdapter("Powered"), GT("bluetooth-disabled"),
+    value = If(!BluezAdapter("Powered"), "bluetooth-disabled",
         if(BluezAdapter("Discovering"), "bluetooth-acquiring", "bluetooth-active"))
     action = Function "XBluezPop"
     action[RightClick] = Menu "XBluezAdapter"


### PR DESCRIPTION
 ` value = If(!BluezAdapter("Powered"), GT("bluetooth-disabled"),`     GT should not be needed here as it is the icon name that does not need to be translated