### PR TITLE
t2.config: better default for tray icons

### DIFF
--- a/config/t2.config
+++ b/config/t2.config
@@ -79,6 +79,7 @@ layout {
 
   tray {
     rows = 1
+    css = "grid { -GtkWidget-column-homogeneous: false; }"
   }
 
   include("battery-svg.widget")


### PR DESCRIPTION
Hidden icons in tray need "-GtkWidget-column-homogeneous: false" in order to stop taking up space.