### PR TITLE
config/battery.widget: fix similarly to battery-svg.widget

### DIFF
--- a/config/battery.widget
+++ b/config/battery.widget
@@ -3,7 +3,33 @@ define BatIcon = "battery-level-" + BatChargeStr + "0" +
         If($BatState = "Discharging","",
           If(BatChargeStr = "10","","-charging"))
 
-Function("BatteryInitScanner"){
+Function BatteryInitScanner() {
+  Var base, dir, sub, file, i, j;
+
+  base = "/sys/class/power_supply";
+  dir = ls(base);
+  i = 0;
+
+  while i<ArraySize(dir) {
+    If Mid(dir[i], 1, 3)="BAT" {
+      sub = ls(base + "/" + dir[i]);
+      j = 0;
+      while j<ArraySize(sub) {
+        file = base + "/" + dir[i] + "/" + sub[j];
+        If mid(sub[j], -5, -1) = "_full"
+          Config "file('" + file + "') { BatTotal = Grab(First) }"
+        If sub[j] = "charge_now" | sub[j] = "energy_now"
+          Config "file('" + file + "') { BatLeft = Grab(First) }"
+        If sub[j] = "status"
+          Config "File ('" + file + "') { BatState = RegEx(\"^(.*)$\",First) }";
+        j = j + 1;
+      }
+    }
+    i = i + 1;
+  }
+}
+
+Function("BatteryInitScanner2"){
   PipeRead "/usr/bin/env python3 << END
 import os
 sysdir = '/sys/class/power_supply'
@@ -35,7 +61,7 @@ END"
 layout {
   style = "module"
   button "battery" {
-    action[0] = Function "BatteryInitScanner"
+    action[0] = BatteryInitScanner
     style = If($BatState="","hidden","module")
     tooltip = Str(100*BatLeft/BatTotal,0) + "%"
     value = BatIcon


### PR DESCRIPTION
This seems to have stopped working, but doesn't give an explicit error. It appears that python is invoked with "<<" as its first argument. Instead of invoking python, use a native script derived from the one `battery-svg` uses.