### PR TITLE
Fix `gtk_radio_menu_item_new_from_widget` warnings

### DIFF
--- a/src/snimenu.c
+++ b/src/snimenu.c
@@ -207,7 +207,7 @@ static GtkWidget *sni_menu_item_new ( guint32 id, GVariant *dict,
       gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(item), state);
   }
   else if(!g_strcmp0(toggle, "radio"))
-    item = gtk_radio_menu_item_new_from_widget(GTK_RADIO_MENU_ITEM(prev));
+    item = gtk_radio_menu_item_new_from_widget(GTK_IS_RADIO_MENU_ITEM(prev) ? GTK_RADIO_MENU_ITEM(prev) : NULL);
   else
     item = gtk_menu_item_new();
 


### PR DESCRIPTION
Without this fix, I see the below output when running sfwbar:
```
$ sfwbar 

(sfwbar:12602): Gtk-CRITICAL **: XX:XX:02.901: gtk_radio_menu_item_new_from_widget: assertion 'group == NULL || GTK_IS_RADIO_MENU_ITEM (group)' failed

(sfwbar:12602): GLib-GObject-CRITICAL **: XX:XX:02.901: g_object_set_data_full: assertion 'G_IS_OBJECT (object)' failed

(sfwbar:12602): GLib-GObject-CRITICAL **: XX:XX:02.901: invalid (NULL) pointer instance

(sfwbar:12602): GLib-GObject-CRITICAL **: XX:XX:02.901: g_signal_connect_data: assertion 'G_TYPE_CHECK_INSTANCE (instance)' failed

(sfwbar:12602): Gtk-CRITICAL **: XX:XX:02.901: gtk_widget_set_name: assertion 'GTK_IS_WIDGET (widget)' failed

(sfwbar:12602): Gtk-CRITICAL **: XX:XX:02.901: gtk_container_add: assertion 'GTK_IS_CONTAINER (container)' failed

(sfwbar:12602): Gtk-CRITICAL **: XX:XX:02.901: gtk_widget_show_all: assertion 'GTK_IS_WIDGET (widget)' failed

(sfwbar:12602): GLib-GObject-CRITICAL **: XX:XX:02.901: g_object_get_data: assertion 'G_IS_OBJECT (object)' failed
XX:XX:02,90 [CRIT ] menu_item_set_sort_index: assertion 'priv' failed

(sfwbar:12602): GLib-GObject-CRITICAL **: XX:XX:02.901: invalid (NULL) pointer instance

(sfwbar:12602): GLib-GObject-CRITICAL **: XX:XX:02.901: g_signal_connect_data: assertion 'G_TYPE_CHECK_INSTANCE (instance)' failed

(sfwbar:12602): Gtk-CRITICAL **: XX:XX:02.901: gtk_container_add: assertion 'GTK_IS_WIDGET (widget)' failed

(sfwbar:12602): Gtk-CRITICAL **: XX:XX:02.901: gtk_widget_set_name: assertion 'GTK_IS_WIDGET (widget)' failed

(sfwbar:12602): GLib-GObject-CRITICAL **: XX:XX:02.901: g_object_get_data: assertion 'G_IS_OBJECT (object)' failed
XX:XX:02,90 [CRIT ] menu_item_set_label: assertion 'priv && priv->label' failed

(sfwbar:12602): GLib-GObject-CRITICAL **: XX:XX:02.901: g_object_get_data: assertion 'G_IS_OBJECT (object)' failed
XX:XX:02,90 [CRIT ] menu_item_set_icon: assertion 'priv && priv->icon' failed

(sfwbar:12602): Gtk-CRITICAL **: XX:XX:02.901: gtk_menu_item_get_submenu: assertion 'GTK_IS_MENU_ITEM (menu_item)' failed

(sfwbar:12602): Gtk-CRITICAL **: XX:XX:02.901: gtk_widget_show_all: assertion 'GTK_IS_WIDGET (widget)' failed

(sfwbar:12602): Gtk-CRITICAL **: XX:XX:02.901: gtk_widget_set_visible: assertion 'GTK_IS_WIDGET (widget)' failed

(sfwbar:12602): GLib-GObject-CRITICAL **: XX:XX:02.901: g_object_get_data: assertion 'G_IS_OBJECT (object)' failed
XX:XX:02,90 [MSG  ] (nil) 0
XX:XX:02,90 [CRIT ] menu_item_get_sort_index: assertion 'priv' failed

(sfwbar:12602): GLib-GObject-CRITICAL **: XX:XX:02.902: g_object_get_data: assertion 'G_IS_OBJECT (object)' failed
XX:XX:02,90 [MSG  ] (nil) 0
XX:XX:02,90 [CRIT ] menu_item_get_sort_index: assertion 'priv' failed

(sfwbar:12602): GLib-GObject-CRITICAL **: XX:XX:02.902: g_object_get_data: assertion 'G_IS_OBJECT (object)' failed
XX:XX:02,90 [MSG  ] (nil) 0
XX:XX:02,90 [CRIT ] menu_item_get_sort_index: assertion 'priv' failed

(sfwbar:12602): GLib-GObject-CRITICAL **: XX:XX:02.902: g_object_get_data: assertion 'G_IS_OBJECT (object)' failed
XX:XX:02,90 [MSG  ] (nil) 0
XX:XX:02,90 [CRIT ] menu_item_get_sort_index: assertion 'priv' failed

(sfwbar:12602): GLib-GObject-CRITICAL **: XX:XX:02.902: g_object_get_data: assertion 'G_IS_OBJECT (object)' failed
XX:XX:02,90 [MSG  ] (nil) 0
XX:XX:02,90 [CRIT ] menu_item_get_sort_index: assertion 'priv' failed
```

Sorry to spam a bunch of PRs all at once. I'd been sitting on a bunch of local changes and figured I should contribute back.