### PR TITLE
config/battery.source: allow non-BATx battery names

### DIFF
--- a/config/battery.source
+++ b/config/battery.source
@@ -22,7 +22,7 @@ Function XBatteryInit() {
   i = 0;
 
   while i<ArraySize(dir) {
-    If Mid(dir[i], 1, 3)="BAT" {
+    If device != '' | Mid(dir[i], 1, 3)="BAT" {
       sub = ls(base + "/" + dir[i]);
       j = 0;
       file_full = ""


### PR DESCRIPTION
If a battery name is specified in the configuration, there is no need to enforce BATx naming for it.