### PR TITLE
gui/scaleimage: fix potential `free(): invalid pointer`

### DIFF
--- a/src/gui/scaleimage.c
+++ b/src/gui/scaleimage.c
@@ -531,9 +531,19 @@ gboolean scale_image_set_image ( GtkWidget *self, const gchar *image,
 
   scale_image_clear(self);
   priv->file = g_strdup(image);
-  priv->extra = extra? g_strdup(extra) :
-    value_get_string(scanner_get_value(g_quark_from_static_string("imagepath"),
-      SCANNER_TYPE_STR, TRUE, NULL));
+
+  if (extra) {
+    priv->extra = g_strdup(extra);
+  } else {
+    value_t maybe_string = scanner_get_value(g_quark_from_static_string("imagepath"),
+      SCANNER_TYPE_STR, TRUE, NULL);
+
+    if (value_is_string(maybe_string)) {
+      priv->extra = value_get_string(maybe_string);
+    } else {
+      priv->extra = g_strdup(NULL);
+    }
+  }
 
   return scale_image_set(self);
 }


### PR DESCRIPTION
Commit c711c2d introduces a crash `free(): invalid pointer` for me instantly at startup, at this location: https://github.com/LBCrion/sfwbar/blob/2a472d9c2e675ea4a87a2f2d812f551c7bafa2eb/src/gui/scaleimage.c#L352

I'm running sfwbar on Debian testing + labwc.

I haven't done any research on the root cause yet unfortunately.