### PR TITLE
gui/popup: fix null dereference when popup_list is uninitialized

### DIFF
--- a/src/gui/popup.c
+++ b/src/gui/popup.c
@@ -83,6 +83,8 @@ void popup_popdown_autoclose ( void )
   GHashTableIter iter;
   GtkWidget *popup;
 
+  if(!popup_list)
+    return;
   g_hash_table_iter_init(&iter, popup_list);
   while(g_hash_table_iter_next(&iter, NULL, (gpointer *)&popup))
     if(gtk_widget_get_visible(popup) &&
@@ -168,10 +170,13 @@ void popup_show ( GtkWidget *parent, GtkWidget *popup, GdkSeat *seat )
   if(!child)
     return;
 
-  g_hash_table_iter_init(&iter, popup_list);
-  while(g_hash_table_iter_next(&iter, NULL, (gpointer *)&old_popup))
-    if(old_popup != popup && gtk_widget_get_visible(old_popup))
-      popup_popdown(old_popup);
+  if(popup_list)
+  {
+    g_hash_table_iter_init(&iter, popup_list);
+    while(g_hash_table_iter_next(&iter, NULL, (gpointer *)&old_popup))
+      if(old_popup != popup && gtk_widget_get_visible(old_popup))
+        popup_popdown(old_popup);
+  }
 
   css_widget_cascade(child, NULL);
   gtk_widget_unrealize(popup);


### PR DESCRIPTION
popup_popdown_autoclose() and popup_show() both call g_hash_table_iter_init() on popup_list without a NULL check. popup_list is lazily initialized in popup_new(), so it remains NULL until the first named popup is created.

When using group=popup on compositors relying on wlr-foreign-toplevel (e.g. labwc), triggering a grouped taskbar popup before any named popup has been created causes a GLib assertion failure and crash:

  GLib-CRITICAL: g_hash_table_iter_init: assertion 'hash_table != NULL' failed

Fix popup_popdown_autoclose() with an early return guard. For popup_show(), wrap the iteration in a NULL check instead of returning early, as subsequent code in that function must still execute.