### PR TITLE
config/upower: add explicit dbus module import

### DIFF
--- a/config/upower.widget
+++ b/config/upower.widget
@@ -1,5 +1,7 @@
 #Api2
 
+module("dbus")
+
 Private {
 
   Var UPowerPropInterface = ["system",


### PR DESCRIPTION
Found that upower.widget does not import the dbus module, and this ends up with a silent failure: no icons and an empty profile list